### PR TITLE
Fix keep-alive: point at relaton/support reusable workflow

### DIFF
--- a/.github/workflows/keep-alive.yml
+++ b/.github/workflows/keep-alive.yml
@@ -4,7 +4,11 @@ name: keep-alive
 on:
   schedule:
   - cron: "0 0 1 * *" # on the first day-of-month
+  workflow_dispatch:
+
+permissions:
+  actions: write
 
 jobs:
   keep-alive:
-    uses: metanorma/ci/.github/workflows/keep-alive.yml@main
+    uses: relaton/support/.github/workflows/keep-alive.yml@main


### PR DESCRIPTION
## Summary

Repoints `.github/workflows/keep-alive.yml` from the broken `metanorma/ci/keep-alive.yml@main` to a new in-org reusable workflow at `relaton/support`. Adds `workflow_dispatch:` so it can be tested manually, and a least-privilege `permissions: actions: write` block.

## Root cause of the failures

The chain `keep-alive.yml → metanorma/ci/keep-alive.yml@main → gautamkrishnar/keepalive-workflow@v1` has been failing every monthly run since 2025-05-01 with **"Repository access blocked"**. Direct check:

```
$ gh api repos/gautamkrishnar/keepalive-workflow
{"message":"Repository access blocked",
 "block":{"reason":"tos","created_at":"2025-04-21T23:04:42Z"}}
```

GitHub blocked the leaf action on **2025-04-21** for a Terms-of-Service violation (dummy commits to defeat the 60-day-inactivity policy). The block is repo-wide — no tag, branch, or SHA resolves. Re-pinning the version cannot fix it.

This is **not** a relaton org policy change and **not** a new GitHub Actions security feature, despite the misleading "access blocked" wording.

## Companion change

Depends on **[relaton/support#50](https://github.com/relaton/support/pull/50)** which adds the new reusable workflow. That PR uses GitHub's official `actions/workflows/{id}/enable` REST API instead of dummy commits — ToS-clean, no third-party action dependency.

Merge order: `relaton/support#50` first, then this PR.

## Part of a sweep

Same broken pattern exists in all `relaton-data-*` repos with `v2` as default. Companion PRs across the family:

- `relaton-data-etsi` — [#4](https://github.com/relaton/relaton-data-etsi/pull/4) (pilot, fully verified)

## Follow-up

Update the `metanorma/cimas` template to emit the new pattern so future regenerations don't undo this fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
